### PR TITLE
changes duplicated `.bottom` item to `.bottomTrailing`

### DIFF
--- a/Sources/SimpleToast/Modifier/SimpleToastSlide.swift
+++ b/Sources/SimpleToast/Modifier/SimpleToastSlide.swift
@@ -19,7 +19,7 @@ struct SimpleToastSlide: SimpleToastModifier {
             case .top, .topLeading, .topTrailing:
                 return .top
 
-            case .bottom, .bottomLeading, .bottom:
+            case .bottom, .bottomLeading, .bottomTrailing:
                 return .bottom
 
             default:


### PR DESCRIPTION
For those using swiftlint, the duplicated `.bottom` item requires to disable the `duplicate_conditions` item.