### PR TITLE
Add `Item` argument to the `content` closure of `simpleToast(item:options:onDismiss:content)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 .vscode/
+.swiftpm

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -1,7 +1,7 @@
 # SimpleToast Usage
 
 There are various ways to attach a toast notification to your views. The basic usage is similar to popular SwiftUI view
-modifiers, such as alert or sheet. If you're familiar with those, using SimpleToast will be straightforward.
+modifiers, such as alert or sheet. If you’re familiar with those, using SimpleToast will be straightforward.
 
 > [!NOTE]
 > The toast always appears at the edges of the view it is attached to. Ensure the view has enough space to render the
@@ -58,7 +58,6 @@ You can trigger the toast via an instance to an optional object, which conforms 
 value is not nil the toast will be shown. The `content` closure receives this object, allowing its data to be used in the toast.
 
 The following example is based on the previous one and also shows the toast, but this time based on a value on an item.
-The toast message will display a property from the `DummyItem`.
 
 ```swift
 import SwiftUI
@@ -148,7 +147,7 @@ and display them in the details view.
 To use the `SimpleToastNotificationPublisher` for your toast notifications, you first need to create a data structure
 that conforms to the `Identifiable` protocol.
 
-Here's a simple example of a toast notification with a text element:
+Here’s a simple example of a toast notification with a text element:
 
 ```swift
 import Foundation

--- a/Documentation/Usage.md
+++ b/Documentation/Usage.md
@@ -1,7 +1,7 @@
 # SimpleToast Usage
 
 There are various ways to attach a toast notification to your views. The basic usage is similar to popular SwiftUI view
-modifiers, such as alert or sheet. If you’re familiar with those, using SimpleToast will be straightforward.
+modifiers, such as alert or sheet. If you're familiar with those, using SimpleToast will be straightforward.
 
 > [!NOTE]
 > The toast always appears at the edges of the view it is attached to. Ensure the view has enough space to render the
@@ -55,9 +55,10 @@ struct ToastTestView: View {
 ## Attach via optional object
 
 You can trigger the toast via an instance to an optional object, which conforms to the protocol Identifiable. If the
-value is not nil the toast will be shown.
+value is not nil the toast will be shown. The `content` closure receives this object, allowing its data to be used in the toast.
 
 The following example is based on the previous one and also shows the toast, but this time based on a value on an item.
+The toast message will display a property from the `DummyItem`.
 
 ```swift
 import SwiftUI
@@ -67,6 +68,7 @@ struct ToastTestView: View {
     @State var showToast: DummyItem? = nil
 
     private struct DummyItem: Identifiable {
+        let id = UUID()
         var foo: String = "Bar"
     }
 
@@ -82,10 +84,10 @@ struct ToastTestView: View {
             }
         }
     }
-    .simpleToast(item: $showToast, options: toastOptions) {
+    .simpleToast(item: $showToast, options: toastOptions) { item in
         HStack {
             Image(systemName: "exclamationmark.triangle")
-            Text("This is some simple toast message.")
+            Text("Item foo: \(item.foo)")
         }
         .padding()
         .background(Color.red.opacity(0.8))
@@ -146,7 +148,7 @@ and display them in the details view.
 To use the `SimpleToastNotificationPublisher` for your toast notifications, you first need to create a data structure
 that conforms to the `Identifiable` protocol.
 
-Here’s a simple example of a toast notification with a text element:
+Here's a simple example of a toast notification with a text element:
 
 ```swift
 import Foundation

--- a/Sources/SimpleToast/Modifier/SimpleToastFade.swift
+++ b/Sources/SimpleToast/Modifier/SimpleToastFade.swift
@@ -9,14 +9,15 @@
 import SwiftUI
 
 /// Modifier for the fade animation
-struct SimpleToastFade: SimpleToastModifier {
-    @Binding var showToast: Bool
+struct SimpleToastFade<Item: Identifiable>: SimpleToastModifier {
+    @Binding var presentationState: PresentationState<Item>
+
     let options: SimpleToastOptions?
 
     func body(content: Content) -> some View {
         content
             .transition(AnyTransition.opacity.animation(options?.animation ?? .linear))
-            .opacity(showToast ? 1 : 0)
+            .opacity(presentationState.isPresented ? 1 : 0)
             .zIndex(1)
     }
 }

--- a/Sources/SimpleToast/Modifier/SimpleToastScale.swift
+++ b/Sources/SimpleToast/Modifier/SimpleToastScale.swift
@@ -9,14 +9,15 @@
 import SwiftUI
 
 /// Modifier for the scale animation
-struct SimpleToastScale: SimpleToastModifier {
-    @Binding var showToast: Bool
+struct SimpleToastScale<Item: Identifiable>: SimpleToastModifier {
+    @Binding var presentationState: PresentationState<Item>
+
     let options: SimpleToastOptions?
 
     func body(content: Content) -> some View {
         content
             .transition(AnyTransition.scale.animation(options?.animation ?? .linear))
-            .opacity(showToast ? 1 : 0)
+            .opacity(presentationState.isPresented ? 1 : 0)
             .zIndex(1)
     }
 }

--- a/Sources/SimpleToast/Modifier/SimpleToastSkew.swift
+++ b/Sources/SimpleToast/Modifier/SimpleToastSkew.swift
@@ -32,8 +32,9 @@ extension AnyTransition {
 }
 
 /// Modifier for the skewing animation
-struct SimpleToastSkew: SimpleToastModifier {
-    @Binding var showToast: Bool
+struct SimpleToastSkew<Item: Identifiable>: SimpleToastModifier {
+    @Binding var presentationState: PresentationState<Item>
+
     let options: SimpleToastOptions?
 
     func body(content: Content) -> some View {

--- a/Sources/SimpleToast/Modifier/SimpleToastSlide.swift
+++ b/Sources/SimpleToast/Modifier/SimpleToastSlide.swift
@@ -9,8 +9,9 @@
 import SwiftUI
 
 /// Modifier foe the slide animation
-struct SimpleToastSlide: SimpleToastModifier {
-    @Binding var showToast: Bool
+struct SimpleToastSlide<Item: Identifiable>: SimpleToastModifier {
+    @Binding var presentationState: PresentationState<Item>
+
     let options: SimpleToastOptions?
 
     private var transitionEdge: Edge {

--- a/Sources/SimpleToast/PresentationState.swift
+++ b/Sources/SimpleToast/PresentationState.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum PresentationState<Item: Identifiable> {
+    case isPresented(Bool)
+    case item(Item?)
+
+    var isPresented: Bool {
+        switch self {
+        case .isPresented(let isPresented):
+            isPresented
+        case .item(let item):
+            item != nil
+        }
+    }
+
+    var item: Item? {
+        switch self {
+        case .isPresented:
+            if isPresented {
+                if let item = EmptyIdentifiable() as? Item {
+                    item
+                } else {
+                    preconditionFailure(
+                        """
+                        Item must be EmptyIdentifiable when using .isPresented state with a boolean binding.
+                        This is an internal library error.
+                        """
+                    )
+                }
+            } else {
+                nil
+            }
+        case .item(let item):
+            item
+        }
+    }
+
+    mutating func dismiss() {
+        switch self {
+        case .isPresented:
+            self = .isPresented(false)
+        case .item:
+            self = .item(nil)
+        }
+    }
+}
+
+struct EmptyIdentifiable: Identifiable {
+    var id: Int { 0 }
+
+    init() {}
+}

--- a/Sources/SimpleToast/SimpleToast.swift
+++ b/Sources/SimpleToast/SimpleToast.swift
@@ -9,8 +9,59 @@
 import SwiftUI
 import Combine
 
-struct SimpleToast<SimpleToastContent: View>: ViewModifier {
-    @Binding var showToast: Bool
+private struct EmptyIdentifiable: Identifiable {
+    var id: Int { 0 }
+
+    init() {}
+}
+
+enum PresentationState<Item: Identifiable> {
+    case isPresented(Bool)
+    case item(Item?)
+
+    var isPresented: Bool {
+        switch self {
+        case .isPresented(let isPresented):
+            isPresented
+        case .item(let item):
+            item != nil
+        }
+    }
+
+    var item: Item? {
+        switch self {
+        case .isPresented:
+            if isPresented {
+                if let item = EmptyIdentifiable() as? Item {
+                    item
+                } else {
+                    preconditionFailure(
+                        """
+                        Item must be EmptyIdentifiable when using .isPresented state with a boolean binding.
+                        This is an internal library error.
+                        """
+                    )
+                }
+            } else {
+                nil
+            }
+        case .item(let item):
+            item
+        }
+    }
+
+    mutating func dismiss() {
+        switch self {
+        case .isPresented:
+            self = .isPresented(false)
+        case .item:
+            self = .item(nil)
+        }
+    }
+}
+
+struct SimpleToast<SimpleToastContent: View, Item: Identifiable>: ViewModifier {
+    @Binding var presentationState: PresentationState<Item>
 
     let options: SimpleToastOptions
     let onDismiss: (() -> Void)?
@@ -20,57 +71,57 @@ struct SimpleToast<SimpleToastContent: View>: ViewModifier {
     @State private var viewState = false
     @State private var cancelable: Cancellable?
 
-    private let toastInnerContent: SimpleToastContent
+    private let toastInnerContent: (Item) -> SimpleToastContent
 
     @ViewBuilder
     private var toastRenderContent: some View {
-        if showToast {
+        if let item = presentationState.item {
             Group {
                 switch options.modifierType {
                 case .slide:
-                    toastInnerContent
-                        .modifier(SimpleToastSlide(showToast: $showToast, options: options))
+                    toastInnerContent(item)
+                        .modifier(SimpleToastSlide(presentationState: $presentationState, options: options))
                         .modifier(SimpleToastDragGestureModifier(offset: $offset, options: options, onCompletion: dismiss))
 
                 case .scale:
-                    toastInnerContent
-                        .modifier(SimpleToastScale(showToast: $showToast, options: options))
+                    toastInnerContent(item)
+                        .modifier(SimpleToastScale(presentationState: $presentationState, options: options))
                         .modifier(SimpleToastDragGestureModifier(offset: $offset, options: options, onCompletion: dismiss))
 
                 case .skew:
-                    toastInnerContent
-                        .modifier(SimpleToastSkew(showToast: $showToast, options: options))
+                    toastInnerContent(item)
+                        .modifier(SimpleToastSkew(presentationState: $presentationState, options: options))
                         // .gesture(dragGesture)
 
 //                case .curtain:
 //                    toastInnerContent
-//                        .modifier(SimpleToastCurtain(showToast: $showToast, options: options))
+//                        .modifier(SimpleToastCurtain(presentationState: $presentationState, options: options))
 //                        .onTapGesture(perform: dismiss)
 
                 default:
-                    toastInnerContent
-                        .modifier(SimpleToastFade(showToast: $showToast, options: options))
+                    toastInnerContent(item)
+                        .modifier(SimpleToastFade(presentationState: $presentationState, options: options))
                         .modifier(SimpleToastDragGestureModifier(offset: $offset, options: options, onCompletion: dismiss))
                 }
             }
             .onTapGesture(perform: dismissOnTap)
             .onAppear(perform: setup)
             .onDisappear { isInit = false }
-            .onReceive(Just(showToast), perform: update)
+            .onReceive(Just(presentationState), perform: update)
             .offset(offset)
         }
     }
 
     init(
-        showToast: Binding<Bool>,
+        presentationState: Binding<PresentationState<Item>>,
         options: SimpleToastOptions,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder content: @escaping () -> SimpleToastContent
+        @ViewBuilder content: @escaping (Item) -> SimpleToastContent
     ) {
-        self._showToast = showToast
+        self._presentationState = presentationState
         self.options = options
         self.onDismiss = onDismiss
-        self.toastInnerContent = content()
+        self.toastInnerContent = content
     }
 
     func body(content: Content) -> some View {
@@ -83,7 +134,7 @@ struct SimpleToast<SimpleToastContent: View>: ViewModifier {
                 Group { EmptyView() }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(options.backdrop?.edgesIgnoringSafeArea(.all))
-                    .opacity(options.backdrop != nil && showToast ? 1 : 0)
+                    .opacity(options.backdrop != nil && presentationState.isPresented ? 1 : 0)
                     .onTapGesture(perform: dismiss)
             )
 
@@ -103,11 +154,11 @@ struct SimpleToast<SimpleToastContent: View>: ViewModifier {
     /// happened. Retriggering the toast resulted in unset timers and thus never disappearing toasts.
     ///
     /// See [the GitHub issue](https://github.com/sanzaru/SimpleToast/issues/24) for more information.
-    private func update(state: Bool) {
+    private func update(state: PresentationState<Item>) {
         // We need to keep track of the current view state and only update on changing values. The onReceive modifier
         // will otherwise constantly trigger updates when the toast is initialized with an Identifiable instead of Bool
-        if state != viewState {
-            viewState = state
+        if state.isPresented != viewState {
+            viewState = state.isPresented
 
             if isInit, viewState {
                 dismissAfterTimeout()
@@ -117,7 +168,7 @@ struct SimpleToast<SimpleToastContent: View>: ViewModifier {
 
     /// Dismiss the sheet after the timeout specified in the options
     private func dismissAfterTimeout() {
-        if let timeout = options.hideAfter, showToast, options.hideAfter != nil {
+        if let timeout = options.hideAfter, presentationState.isPresented, options.hideAfter != nil {
             cancelable = Timer.publish(every: timeout, on: .main, in: .common)
                 .autoconnect()
                 .sink { _ in
@@ -131,7 +182,7 @@ struct SimpleToast<SimpleToastContent: View>: ViewModifier {
     private func dismiss() {
         withAnimation(options.animation) {
             cancelable?.cancel()
-            showToast = false
+            presentationState.dismiss()
             viewState = false
             offset = .zero
 
@@ -162,7 +213,19 @@ public extension View {
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> SimpleToastContent) -> some View {
         self.modifier(
-            SimpleToast(showToast: isPresented, options: options, onDismiss: onDismiss, content: content)
+            SimpleToast(
+                presentationState: Binding<PresentationState<EmptyIdentifiable>>(
+                    get: {
+                        .isPresented(isPresented.wrappedValue)
+                    },
+                    set: { presentationState in
+                        isPresented.wrappedValue = presentationState.isPresented
+                    }
+                ),
+                options: options,
+                onDismiss: onDismiss,
+                content: { _ in content() }
+            )
         )
     }
 
@@ -177,21 +240,34 @@ public extension View {
     ///   - content: Inner content for the toast
     /// - Returns: The toast view
     func simpleToast<SimpleToastContent: View, Item: Identifiable>(
-        item: Binding<Item?>?, options: SimpleToastOptions,
+        item: Binding<Item?>, options: SimpleToastOptions,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder content: @escaping () -> SimpleToastContent
+        @ViewBuilder content: @escaping (Item) -> SimpleToastContent
     ) -> some View {
-        let bindingProxy = Binding<Bool>(
-            get: { item?.wrappedValue != nil },
-            set: {
-                if !$0 {
-                    item?.wrappedValue = nil
-                }
-            }
-        )
-
-        return self.modifier(
-            SimpleToast(showToast: bindingProxy, options: options, onDismiss: onDismiss, content: content)
+        self.modifier(
+            SimpleToast(
+                presentationState: Binding<PresentationState<Item>>(
+                    get: {
+                        .item(item.wrappedValue)
+                    },
+                    set: { presentationState in
+                        switch presentationState {
+                        case .item(let newItem):
+                            item.wrappedValue = newItem
+                        case .isPresented:
+                            preconditionFailure(
+                                """
+                                When using the simpleToast modifier with an 'item' binding (Binding<Item?>),
+                                the presentationState is expected to be '.item(Item?)'.
+                                """
+                            )
+                        }
+                    }
+                ),
+                options: options,
+                onDismiss: onDismiss,
+                content: content
+            )
         )
     }
 }
@@ -212,8 +288,6 @@ public extension View {
         isShowing: Binding<Bool>, options: SimpleToastOptions,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> SimpleToastContent) -> some View {
-        self.modifier(
-            SimpleToast(showToast: isShowing, options: options, onDismiss: onDismiss, content: content)
-        )
+            simpleToast(isPresented: isShowing, options: options, onDismiss: onDismiss, content: content)
     }
 }

--- a/Sources/SimpleToast/SimpleToast.swift
+++ b/Sources/SimpleToast/SimpleToast.swift
@@ -9,57 +9,6 @@
 import SwiftUI
 import Combine
 
-private struct EmptyIdentifiable: Identifiable {
-    var id: Int { 0 }
-
-    init() {}
-}
-
-enum PresentationState<Item: Identifiable> {
-    case isPresented(Bool)
-    case item(Item?)
-
-    var isPresented: Bool {
-        switch self {
-        case .isPresented(let isPresented):
-            isPresented
-        case .item(let item):
-            item != nil
-        }
-    }
-
-    var item: Item? {
-        switch self {
-        case .isPresented:
-            if isPresented {
-                if let item = EmptyIdentifiable() as? Item {
-                    item
-                } else {
-                    preconditionFailure(
-                        """
-                        Item must be EmptyIdentifiable when using .isPresented state with a boolean binding.
-                        This is an internal library error.
-                        """
-                    )
-                }
-            } else {
-                nil
-            }
-        case .item(let item):
-            item
-        }
-    }
-
-    mutating func dismiss() {
-        switch self {
-        case .isPresented:
-            self = .isPresented(false)
-        case .item:
-            self = .item(nil)
-        }
-    }
-}
-
 struct SimpleToast<SimpleToastContent: View, Item: Identifiable>: ViewModifier {
     @Binding var presentationState: PresentationState<Item>
 

--- a/Sources/SimpleToast/SimpleToastModifier.swift
+++ b/Sources/SimpleToast/SimpleToastModifier.swift
@@ -12,6 +12,7 @@ import SwiftUI
 /// The basic building blocks are a boolean value determining whether to show the toast or not and an instance of a SimpleToastOptions object, which is optional.
 @MainActor
 protocol SimpleToastModifier: ViewModifier {
-    var showToast: Bool { get set }
+    associatedtype Item: Identifiable
+    var presentationState: PresentationState<Item> { get set }
     var options: SimpleToastOptions? { get }
 }


### PR DESCRIPTION
I updated the content closure of simpleToast(item:options:onDismiss:content) to accept an Item argument.
This change follows the design of Apple’s `sheet(item:content)`.
Additionally, the type of the `item` parameter has been updated from `Binding<Item?>?` to `Binding<Item?>` to match this behavior.
